### PR TITLE
Fixing typespecs for topic and messages on pubsub

### DIFF
--- a/lib/pub_sub.ex
+++ b/lib/pub_sub.ex
@@ -7,8 +7,8 @@ defmodule PubSub do
 
   use GenServer
 
-  @type topic :: binary
-  @type message :: binary
+  @type topic :: atom
+  @type message :: any
 
   ## Client API
 
@@ -55,7 +55,7 @@ defmodule PubSub do
       iex> PubSub.publish(:my_topic, "Hi there!")
       :ok
   """
-  @spec publish(binary, message) :: :ok
+  @spec publish(topic, message) :: :ok
   def publish(topic, message) do
     GenServer.cast(__MODULE__, {:publish, %{topic: topic, message: message}})
   end


### PR DESCRIPTION
Your own examples were not matching with the given topic type. And it's quite useful to be able to send anything you want in the message.