### PR TITLE
Making easier to use PubSub on a Supervisor

### DIFF
--- a/lib/pub_sub.ex
+++ b/lib/pub_sub.ex
@@ -15,7 +15,9 @@ defmodule PubSub do
   @doc """
   Starts the server.
   """
-  def start_link() do
+  @spec start_link() :: GenServer.on_start()
+  @spec start_link(list) :: GenServer.on_start()
+  def start_link(_args \\ []) do
     GenServer.start_link(__MODULE__, :ok, [{:name, __MODULE__}])
   end
 
@@ -93,6 +95,13 @@ defmodule PubSub do
     GenServer.call(__MODULE__, {:topics})
   end
 
+  @spec child_spec(list) :: map
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
 
   ## Callbacks
 
@@ -161,5 +170,4 @@ defmodule PubSub do
   defp find_process(pid) when is_atom(pid) do
     Process.whereis(pid)
   end
-  
 end

--- a/test/pub_sub_test.exs
+++ b/test/pub_sub_test.exs
@@ -11,6 +11,13 @@ defmodule PubSubTest do
     end
   end
 
+  test "child_spec returns the child spec for supervisors" do
+    assert PubSub.child_spec(arg: 1) == %{
+      id: PubSub,
+      start: {PubSub, :start_link, [[arg: 1]]}
+    }
+  end
+
   test "processes can subscribe to topics" do
     [pid1, pid2, pid3] = spawn_multiple(3)
     {topic1, topic2} = {:erlang, :elixir}


### PR DESCRIPTION
Closes #5

As you can see, I added the `start_link/1` so one can use `Supervisor.child_spec(PubSub)` on
supervisor's child list.

Also, I've created the `child_spec/1` function, which makes it possible to use directly `PubSub`
on the supervisor child list.