### PR TITLE
Issue #6 Duplicate subscription fix

### DIFF
--- a/lib/pub_sub.ex
+++ b/lib/pub_sub.ex
@@ -113,7 +113,11 @@ defmodule PubSub do
   def handle_cast({:subscribe, %{topic: topic, pid: pid}}, state) do
     pid = find_process(pid)
     Process.link(pid)
-    new_state = Map.put(state, topic, [pid | get_subscribers(topic, state)])
+    subscribers = get_subscribers(topic, state)
+    new_state = case Enum.any?(subscribers, fn p -> p == pid end) do
+      true  -> state
+      false -> Map.put(state, topic, [pid | subscribers])
+    end
     {:noreply, new_state}
   end
 

--- a/test/pub_sub_test.exs
+++ b/test/pub_sub_test.exs
@@ -30,6 +30,15 @@ defmodule PubSubTest do
     assert PubSub.subscribers(topic2) == [pid3]
   end
 
+  test "duplicate subscriptions are ignored" do
+    [pid1] = spawn_multiple(1)
+
+    PubSub.subscribe(pid1, :topic)
+    PubSub.subscribe(pid1, :topic)
+
+    assert PubSub.subscribers(:topic) == [pid1]
+   end
+
   test "processes can unsubscribe from topics" do
     [pid1, pid2, pid3] = spawn_multiple(3)
     {topic1, topic2} = {:erlang, :elixir}


### PR DESCRIPTION
Duplicate subscription requests are a no-op as suggested.